### PR TITLE
Combine multiple memo fields

### DIFF
--- a/src/lib/parser.spec.fixtures.ts
+++ b/src/lib/parser.spec.fixtures.ts
@@ -25,6 +25,11 @@ invalid footer row
   `1;9/27/2020;871,13;Devpoint;IL95 2010 7730 7319 4618 209
 2;11/26/2019;908,31;Realcube;GE78 WG91 9644 2111 5080 45
 3;3/6/2020;152,13;Oyoloo;GR11 2705 328W VAZB OZUD NLWB DJT`,
+
+  // Multiple memo columns
+  `1;9/27/2020;871.13;memo A;memo B
+2;11/26/2019;908.31;memo A;memo B
+3;3/6/2020;152.13;memo A;memo B`,
 ];
 
 export const defaultParser: Parser =

--- a/src/lib/parser.spec.ts
+++ b/src/lib/parser.spec.ts
@@ -52,7 +52,7 @@ describe("parser", () => {
     result.transactions.forEach((tx) => {
       expect(tx.memo).toEqual("memo A memo B");
     });
-  })
+  });
 });
 
 const runParser = (fixtureId: number, parseCfg?: Partial<Parser>) => {

--- a/src/lib/parser.spec.ts
+++ b/src/lib/parser.spec.ts
@@ -43,6 +43,16 @@ describe("parser", () => {
       expect(inflow).toEqual(-outflow);
     }
   });
+
+  it("merges multiple memo columns together", () => {
+    const parseCfg = { columns: ["", "date", "amount", "memo", "memo2"] };
+    const result = runParser(csvFixtures.multipleMemoColumns, parseCfg);
+    expect(result.transactions).toHaveLength(3);
+    result.transactions.forEach(validateTransaction);
+    result.transactions.forEach((tx) => {
+      expect(tx.memo).toEqual("memo A memo B");
+    });
+  })
 });
 
 const runParser = (fixtureId: number, parseCfg?: Partial<Parser>) => {
@@ -57,7 +67,7 @@ enum csvFixtures {
   customDelimiter = 0,
   headerFooterEmptyLines = 1,
   decimalCommas = 2,
-  outflow = 3,
+  multipleMemoColumns = 3,
 }
 
 const validateTransaction = (tx: Transaction) => {

--- a/src/lib/parser.ts
+++ b/src/lib/parser.ts
@@ -5,7 +5,6 @@ import { DateTime, Zone } from "luxon";
 import fs from "fs";
 import chalk from "chalk";
 import { messages } from "../constants";
-import path from "path";
 
 export function parseBankFile(source: BankFile, parsers: Parser[]) {
   const csv = fs.readFileSync(source.path);
@@ -36,8 +35,15 @@ export function buildTransaction(record: any, parser: Parser): Transaction {
   return {
     amount: parseAmount(record),
     date: parseDate(record, parser.date_format),
-    memo: record.memo,
+    memo: mergeMemoFields(record),
   };
+}
+
+function mergeMemoFields(record: any) {
+  // Merge fields named memo, memo1, memo2, etc. into a single memo field
+  const memoFields = Object.keys(record).filter((key) => key.match(/^memo[0-9]*$/)).sort();
+  const allMemos = memoFields.map((key) => record[key]);
+  return allMemos.join(" ");
 }
 
 function parseDate(record: any, dateFormat: string) {
@@ -75,13 +81,13 @@ function logResult(txCount: number, sourcePath: string) {
  * Turns a list of column names into a list where only allowed columns exist.
  * Ignored columns are kept, but receive a unique name.
  * That way they are still parsed, but ignored later on.
- * Example input: ['skip', 'memo', 'skip', 'Date', 'Inflow', 'Foobar'] ==>
- * output: ['_0', 'memo', '_1', 'date', 'inflow', '_3']
+ * Example input: ['skip', 'memo', 'skip', 'Date', 'Inflow', 'Foobar', 'memo2'] ==>
+ * output: ['_0', 'memo', '_1', 'date', 'inflow', '_3', 'memo2']
  */
 function unifyColumns(columnName: string, index: number) {
   const columnLowerCase = columnName.toLowerCase();
-  const allowedColumns = ["date", "inflow", "outflow", "amount", "memo"];
-  const isAllowed = allowedColumns.includes(columnLowerCase);
+  const allowedColumns = [/^date$/, /^inflow$/, /^outflow$/, /^amount$/, /^memo[0-9]*$/];
+  const isAllowed = allowedColumns.some((regex) => columnLowerCase.match(regex));
   if (isAllowed) return columnLowerCase;
   else return `__${index}`;
 }

--- a/src/lib/parser.ts
+++ b/src/lib/parser.ts
@@ -41,7 +41,9 @@ export function buildTransaction(record: any, parser: Parser): Transaction {
 
 function mergeMemoFields(record: any) {
   // Merge fields named memo, memo1, memo2, etc. into a single memo field
-  const memoFields = Object.keys(record).filter((key) => key.match(/^memo[0-9]*$/)).sort();
+  const memoFields = Object.keys(record)
+    .filter((key) => key.match(/^memo[0-9]*$/))
+    .sort();
   const allMemos = memoFields.map((key) => record[key]);
   return allMemos.join(" ");
 }
@@ -86,8 +88,16 @@ function logResult(txCount: number, sourcePath: string) {
  */
 function unifyColumns(columnName: string, index: number) {
   const columnLowerCase = columnName.toLowerCase();
-  const allowedColumns = [/^date$/, /^inflow$/, /^outflow$/, /^amount$/, /^memo[0-9]*$/];
-  const isAllowed = allowedColumns.some((regex) => columnLowerCase.match(regex));
+  const allowedColumns = [
+    /^date$/,
+    /^inflow$/,
+    /^outflow$/,
+    /^amount$/,
+    /^memo[0-9]*$/,
+  ];
+  const isAllowed = allowedColumns.some((regex) =>
+    columnLowerCase.match(regex)
+  );
   if (isAllowed) return columnLowerCase;
   else return `__${index}`;
 }


### PR DESCRIPTION
This PR adds a new feature:

* If a CSV contains multiple columns that can be used as a memo, 
  they can now be named `'memo', 'memo2', 'memo3'`, and so on.
* This feature will then combine those columns together into a single Memo field