### PR TITLE
Parse Dates Surrounded by Spaces Without Exception

### DIFF
--- a/src/lib/parser.spec.fixtures.ts
+++ b/src/lib/parser.spec.fixtures.ts
@@ -40,6 +40,11 @@ invalid footer row
   `1;9/27/2020;98.99;Devpoint;YNAB
 2;11/26/2019;420.69;Realcube;Amazon
 3;3/6/2020;9.99;Oyoloo;Netflix`,
+
+  // Date surrounded by spaces
+  `1; 9/27/2020 ;871.13;Devpoint;IL95 2010 7730 7319 4618 209
+2; 11/26/2019 ;908.31;Realcube;GE78 WG91 9644 2111 5080 45
+3; 3/6/2020 ;152.13;Oyoloo;GR11 2705 328W VAZB OZUD NLWB DJT`,
 ];
 
 export const defaultParser: Parser =

--- a/src/lib/parser.spec.ts
+++ b/src/lib/parser.spec.ts
@@ -74,6 +74,12 @@ describe("parser", () => {
       expect(tx.payee_name!.length).toBeGreaterThan(0);
     });
   });
+
+  it("can parse dates surrounded by spaces without exceptions", () => {
+    const parseCfg = { columns: ["", "date", "amount", "memo", "memo2"] };
+    const result = runParser(csvFixtures.dateSurroundedBySpaces, parseCfg);
+    expect(result.transactions).toHaveLength(3);
+  });
 });
 
 const runParser = (fixtureId: number, parseCfg?: Partial<Parser>) => {
@@ -91,6 +97,7 @@ enum csvFixtures {
   multipleMemoColumns = 3,
   inOutIndicator = 4,
   payeeField = 5,
+  dateSurroundedBySpaces = 6,
 }
 
 const validateTransaction = (tx: Transaction) => {

--- a/src/lib/parser.ts
+++ b/src/lib/parser.ts
@@ -52,7 +52,7 @@ function mergeMemoFields(record: any) {
 
 function parseDate(record: any, dateFormat: string) {
   const { date } = record;
-  const dateTime = DateTime.fromFormat(date, dateFormat, { zone: "UTC" });
+  const dateTime = DateTime.fromFormat(date.trim(), dateFormat, { zone: "UTC" });
   if (dateTime.isValid) return dateTime.toJSDate();
 
   const error = messages.parseDateError.join("\n");

--- a/src/lib/parser.ts
+++ b/src/lib/parser.ts
@@ -52,7 +52,9 @@ function mergeMemoFields(record: any) {
 
 function parseDate(record: any, dateFormat: string) {
   const { date } = record;
-  const dateTime = DateTime.fromFormat(date.trim(), dateFormat, { zone: "UTC" });
+  const dateTime = DateTime.fromFormat(date.trim(), dateFormat, {
+    zone: "UTC",
+  });
   if (dateTime.isValid) return dateTime.toJSDate();
 
   const error = messages.parseDateError.join("\n");


### PR DESCRIPTION
When a date is surrounded by space, the date library fails to parse it
This commit is to trim the date field before parsing date fields.