### PR TITLE
Add currency_rate setting; Rename field payee_name to payee

### DIFF
--- a/src/lib/parser.spec.ts
+++ b/src/lib/parser.spec.ts
@@ -71,8 +71,8 @@ describe("parser", () => {
     const result = runParser(csvFixtures.payeeField, parseCfg);
     expect(result.transactions).toHaveLength(3);
     result.transactions.forEach((tx) => {
-      expect(tx.payee_name).toBeDefined();
-      expect(tx.payee_name!.length).toBeGreaterThan(0);
+      expect(tx.payee).toBeDefined();
+      expect(tx.payee!.length).toBeGreaterThan(0);
     });
   });
 

--- a/src/lib/uploader.spec.fixtures.ts
+++ b/src/lib/uploader.spec.fixtures.ts
@@ -21,7 +21,7 @@ export const parsedBankFile: ParsedBankFile = {
       amount: 420,
       date: new Date("1990-02-27"),
       memo: "tx1",
-      payee_name: "payee1",
+      payee: "payee1",
     },
     {
       amount: 420,
@@ -50,7 +50,7 @@ export const expectedTransactions = [
     cleared: "cleared",
     account_id: "testAccountId",
     flag_color: "purple",
-    payee_name: "payee1",
+    payee: "payee1",
     occurrence: 1,
   },
   {

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,6 +20,7 @@ export type BankFilePattern = {
   upload: boolean;
   save_parsed_file: boolean;
   delete_original_file: boolean;
+  currency_rate?: number;
 };
 
 export type BankFile = {
@@ -43,7 +44,7 @@ export type Transaction = {
   date: Date;
   account_id?: string;
   flag_color?: string;
-  payee_name?: string;
+  payee?: string;
 };
 
 export type Parser = {


### PR DESCRIPTION
It allows to multiply values from source csv to transaction rate. For case when bank account in one currency and ynab account in another.

Also payee_name renamed to payee. This way ynab native csv import works correctly