### PR TITLE
feat: skip import path confirmation

### DIFF
--- a/docs/how-to-configure.md
+++ b/docs/how-to-configure.md
@@ -22,6 +22,13 @@ import_from: "/home/niels/downloads"    # linux, mac os
 
 **Optional:** If no folder is set, ynab-buddy will ask where to find your files every time.
 
+### `skip_path_confirmation`
+
+Set to `true` to always use `import_from` without confirmation
+
+
+**Optional.**
+
 ### `search_subfolders`
 
 ```yaml

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { exportCsv, findBankFiles, cleanup } from "./lib/filesystem";
 import { parseBankFile } from "./lib/parser";
 import { upload } from "./lib/uploader";
 import { BankFile } from "./types";
+import fs from "fs";
 
 (async () => {
   // Ensure the tool has a valid configuration
@@ -17,7 +18,11 @@ import { BankFile } from "./types";
   if (!config.configurationDone) return cli.exitApp();
 
   // Confirm folder where the tool should look for bank files
-  config.importPath = await cli.confirmImportPath(config.importPath);
+  const importPathExists =
+    config.importPath && fs.existsSync(config.importPath);
+  if (!config.skipPathConfirmation || !importPathExists) {
+    config.importPath = await cli.confirmImportPath(config.importPath);
+  }
 
   // Find files eligible for conversion in the importPath
   const bankFiles = findBankFiles(config.importPath!, config);

--- a/src/lib/configuration.spec.ts
+++ b/src/lib/configuration.spec.ts
@@ -63,6 +63,7 @@ describe("configuration", () => {
           pattern: "BNP-export-IBAN01233456789-*.csv",
         },
       ],
+      skipPathConfirmation: false,
       configurationDone: false,
       parsers: [
         {

--- a/src/lib/configuration.ts
+++ b/src/lib/configuration.ts
@@ -84,6 +84,7 @@ const readConfigFile = () => {
 const parseRawConfig = (rawConfig: any): Configuration => {
   return {
     importPath: rawConfig.import_from,
+    skipPathConfirmation: !!rawConfig.skip_path_confirmation,
     searchSubDirectories: !!rawConfig.search_subdirectories,
     bankFilePatterns: rawConfig.bank_transaction_files,
     ynab: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,6 @@
 export type Configuration = {
   importPath?: string; // FIXME: Can i remove the '?' ?
+  skipPathConfirmation?: boolean;
   searchSubDirectories: boolean;
   parsers: Parser[];
   bankFilePatterns: BankFilePattern[];


### PR DESCRIPTION
Adds an option 'skip_path_confirmation' that allows to always use the default import_from path without having to confirm it every time

Closes #47 