### PR TITLE
Corrected "search_subfolder" instructions

### DIFF
--- a/assets/config/example.yaml
+++ b/assets/config/example.yaml
@@ -8,7 +8,7 @@
 # https://github.com/nielsmaerten/ynab-buddy/blob/main/docs/how-to-configure.md
 
 import_from: "c:/users/test/downloads"
-search_subfolders: true
+search_subdirectories: true
 
 bank_transaction_files:
   # Repeat the following block for every account:

--- a/docs/how-to-configure.md
+++ b/docs/how-to-configure.md
@@ -29,11 +29,11 @@ Set to `true` to always use `import_from` without confirmation
 
 **Optional.**
 
-### `search_subfolders`
+### `search_subdirectories`
 
 ```yaml
-search_subfolders: false # only search the top folder for bank files
-search_subfolders: true  # search underlying folders as well
+search_subdirectories: false # only search the top folder for bank files
+search_subdirectories: true  # search underlying folders as well
 ```
 
 ### `configuration_done`

--- a/src/lib/configuration.spec.fixture.ts
+++ b/src/lib/configuration.spec.fixture.ts
@@ -15,7 +15,7 @@ export const configFile = `#######################################
 # https://github.com/nielsmaerten/ynab-buddy/blob/main/docs/how-to-configure.md
 
 import_from: "c:/users/test/downloads"
-search_subfolders: true
+search_subdirectories: true
 
 bank_transaction_files:
   # Repeat the following block for every account:

--- a/src/lib/configuration.spec.ts
+++ b/src/lib/configuration.spec.ts
@@ -75,7 +75,7 @@ describe("configuration", () => {
           name: "bnp-example-parser",
         },
       ],
-      searchSubDirectories: false,
+      searchSubDirectories: true,
       importPath: "c:/users/test/downloads",
       ynab: {
         token: "ABC12345",


### PR DESCRIPTION
The option to search for csvs within Subfolders seems to have changed from "search_subfolders" to "search_subdirectories". I have updated the documentation to match.