### PR TITLE
chore: upgrade to node 18

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 {
 	"name": "ynab-buddy",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/typescript-node:0-18",
+	"image": "mcr.microsoft.com/devcontainers/typescript-node:0-20",
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	"features": {
 		"github-cli": "latest",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 {
 	"name": "ynab-buddy",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/typescript-node:0-20",
+	"image": "mcr.microsoft.com/devcontainers/typescript-node:0-18",
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	"features": {
 		"github-cli": "latest",

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [18.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
@@ -30,12 +30,12 @@ jobs:
       - run: yarn package:rebuild --compress Brotli
 
       - name: Codecov
-        if: matrix.node-version == '20.x'
+        if: matrix.node-version == '18.x'
         uses: codecov/codecov-action@v2.1.0
 
       - name: Release
         uses: softprops/action-gh-release@v1
-        if: startsWith(github.ref, 'refs/tags/') && matrix.node-version == '20.x'
+        if: startsWith(github.ref, 'refs/tags/') && matrix.node-version == '18.x'
         with:
           draft: true
           fail_on_unmatched_files: true

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -2,42 +2,41 @@ name: Node.js CI
 
 on:
   push:
-    branches: [ main ]
-    tags: 
-      - 'v*.*.*'
+    branches: [main]
+    tags:
+      - "v*.*.*"
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [18.x, 20.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ matrix.node-version }}
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
 
-    - run: yarn
-    - run: yarn test
-    - run: yarn lint
-    - run: yarn package:rebuild --compress Brotli
+      - run: yarn
+      - run: yarn test
+      - run: yarn lint
+      - run: yarn package:rebuild --compress Brotli
 
-    - name: Codecov
-      if: matrix.node-version == '16.x'
-      uses: codecov/codecov-action@v2.1.0
+      - name: Codecov
+        if: matrix.node-version == '20.x'
+        uses: codecov/codecov-action@v2.1.0
 
-    - name: Release
-      uses: softprops/action-gh-release@v1
-      if: startsWith(github.ref, 'refs/tags/') && matrix.node-version == '16.x'
-      with:
-        draft: true
-        fail_on_unmatched_files: true
-        files: bin/*
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/') && matrix.node-version == '20.x'
+        with:
+          draft: true
+          fail_on_unmatched_files: true
+          files: bin/*


### PR DESCRIPTION
This drops support for node versions <18 and makes 18 the new default.  
Other versions are still likely to work, but as the Node project is moving on, upgrading is recommended.