### PR TITLE
bugfix: remove timestamp from ynab.csv files

### DIFF
--- a/src/lib/filesystem.ts
+++ b/src/lib/filesystem.ts
@@ -79,7 +79,7 @@ export function exportCsv(result: ParsedBankFile) {
   if (!shouldExport) return;
 
   // Produce a CSV file that can be read by YNAB
-  const castDate = (d: Date) => d.toISOString();
+  const castDate = (d: Date) => d.toISOString().substring(0, 10);
   const exportConfig: stringify.Options = {
     header: true,
     cast: { date: castDate },


### PR DESCRIPTION
Fixes #246 

When creating a ynab.csv file, the date fields should contain the date in format yyyy-mm-dd.  
Instead, we were putting a full ISO timestamp in the column, which is not accepted by YNAB.

This PR should fix that.