### PR TITLE
fix: wrongly calculated amount if inflow and outflow are strings and inflow is 0

### DIFF
--- a/src/lib/parser.spec.fixtures.ts
+++ b/src/lib/parser.spec.fixtures.ts
@@ -67,6 +67,16 @@ invalid footer row
 ,,30/08/2020,POS-xxxxxxx,,-7.00,EUR
 ,01/09/2020,01/09/2020,Disposizione - RIF:xxxxxxx,,-180.00,EUR
 ,01/09/2020,31/08/2020,Addebito canone -xxxxxxx,100.00,,EUR`,
+
+// https://github.com/nielsmaerten/ynab-buddy/pull/269
+  // This demonstrates a bug discovered by @tobim-dev:
+  // If there's an inflow column containing "0", 
+  // the parser should ignore it if there's also an outflow column.
+  // Use case: bank uses inflow/outflow columns,
+  // and in case of outflow writes "0" in inflow column:
+  `index,date,inflow,outflow,payee
+  1,9/27/2020,0,420.69,Devpoint`
+
 ];
 
 export const defaultParser: Parser =

--- a/src/lib/parser.spec.ts
+++ b/src/lib/parser.spec.ts
@@ -189,6 +189,17 @@ describe("parser", () => {
     expect(result.transactions[1].amount).toEqual(-180);
     expect(result.transactions[2].amount).toEqual(100);
   });
+
+  it("handles an inflow column containing '0'", () => {
+    const parseCfg = {
+      columns: ["", "date", "inflow", "outflow", "payee"],
+      decimal_separator: ".",
+      delimiter: ",",
+      header_rows: 1,
+    };
+    const result = runParser(csvFixtures.inflow0, parseCfg);
+    expect(result.transactions[0].amount).toEqual(-420.69);
+  });
 });
 
 const runParser = (fixtureId: number, parseCfg?: Partial<Parser>) => {
@@ -211,6 +222,7 @@ enum csvFixtures {
   dotThousandSeparatorsCommaDecimalSeparator = 8,
   inflowOutflowColumns = 9,
   githubIssue45 = 10,
+  inflow0 = 11,
 }
 
 const validateTransaction = (tx: Transaction) => {

--- a/src/lib/parser.ts
+++ b/src/lib/parser.ts
@@ -75,9 +75,9 @@ function parseDate(record: any, dateFormat: string) {
 }
 
 function getValue(inflow: any, outflow: any, amount: any) {
-  if (inflow !== undefined && inflow !== "0" && inflow !== 0) {
+  if (inflow && inflow !== "0" && inflow !== 0) {
     return inflow;
-  } else if (outflow !== undefined && outflow !== "0" && outflow !== 0) {
+  } else if (outflow && outflow !== "0" && outflow !== 0) {
     return outflow;
   } else {
     return amount;
@@ -112,15 +112,9 @@ function parseAmount(record: any, parser: Parser): number {
   // Invert the value if this transaction is an outflow
   const hasOutflowFlag = Boolean(in_out_flag?.startsWith(outflow_indicator));
   const hasOutflowValue =
-    outflow?.length > 0 &&
-    outflow !== undefined &&
-    outflow !== "0" &&
-    outflow !== 0;
+    outflow?.length > 0 && outflow && outflow !== "0" && outflow !== 0;
   const hasInflowValue =
-    inflow?.length > 0 &&
-    inflow !== undefined &&
-    inflow !== "0" &&
-    inflow !== 0;
+    inflow?.length > 0 && inflow && inflow !== "0" && inflow !== 0;
   const isOutflow = (hasOutflowValue && !hasInflowValue) || hasOutflowFlag;
   if (isOutflow) {
     value = Math.abs(value) * -1;

--- a/src/lib/parser.ts
+++ b/src/lib/parser.ts
@@ -74,10 +74,20 @@ function parseDate(record: any, dateFormat: string) {
   throw "PARSING ERROR";
 }
 
+function getValue(inflow: any, outflow: any, amount: any) {
+  if (inflow !== undefined && inflow !== "0" && inflow !== 0) {
+    return inflow;
+  } else if (outflow !== undefined && outflow !== "0" && outflow !== 0) {
+    return outflow;
+  } else {
+    return amount;
+  }
+}
+
 function parseAmount(record: any, parser: Parser): number {
   const { thousand_separator, decimal_separator, outflow_indicator } = parser;
   const { inflow, outflow, amount, in_out_flag } = record;
-  let value = inflow || outflow || amount;
+  let value = getValue(inflow, outflow, amount);
 
   if (typeof value === "string") {
     if (thousand_separator) {
@@ -101,9 +111,17 @@ function parseAmount(record: any, parser: Parser): number {
 
   // Invert the value if this transaction is an outflow
   const hasOutflowFlag = Boolean(in_out_flag?.startsWith(outflow_indicator));
-  const hasOutflowColumn = outflow?.length > 0;
-  const hasInflowColumn = inflow?.length > 0;
-  const isOutflow = (hasOutflowColumn && !hasInflowColumn) || hasOutflowFlag;
+  const hasOutflowValue =
+    outflow?.length > 0 &&
+    outflow !== undefined &&
+    outflow !== "0" &&
+    outflow !== 0;
+  const hasInflowValue =
+    inflow?.length > 0 &&
+    inflow !== undefined &&
+    inflow !== "0" &&
+    inflow !== 0;
+  const isOutflow = (hasOutflowValue && !hasInflowValue) || hasOutflowFlag;
   if (isOutflow) {
     value = Math.abs(value) * -1;
   }


### PR DESCRIPTION
Given that the `inflow` and `outflow` columns are used, both of which are strings, and the inflow column is `'0'`, the calculated amount is always `0`. This is because JavaScript takes the left value of an II expression if it's truthy, and `'0'` is considered truthy.

In the fix, I explicitly check for `'0'`.