### PR TITLE
feat: skip transaction upload if no transactions are parsed

### DIFF
--- a/src/lib/uploader.spec.fixtures.ts
+++ b/src/lib/uploader.spec.fixtures.ts
@@ -80,3 +80,15 @@ export const expectedTransactions = [
     flag_color: "purple",
   },
 ];
+
+export const emptyTransactionsParsedBankFile: ParsedBankFile = {
+  source: {
+    matchedPattern: {
+      upload: true,
+      ynab_account_id: "testAccountId",
+      ynab_budget_id: "testBudgetId",
+      ynab_flag_color: "purple",
+    },
+  } as any,
+  transactions: [],
+};

--- a/src/lib/uploader.spec.ts
+++ b/src/lib/uploader.spec.ts
@@ -23,4 +23,10 @@ describe("uploader", () => {
     const transactions = sendToYnab.mock.calls[0][0];
     expect(transactions).toEqual(fixture.expectedTransactions);
   });
+
+  it("skips sending transactions to YNAB if no transactions are parsed.", () => {
+    const sendToYnab = uploader.sendToYnab as jest.Mock;
+    uploader.upload(fixture.emptyTransactionsParsedBankFile, fixture.config);
+    expect(sendToYnab).not.toHaveBeenCalled();
+  });
 });

--- a/src/lib/uploader.ts
+++ b/src/lib/uploader.ts
@@ -16,6 +16,9 @@ export function upload(parsedFile: ParsedBankFile, config: Configuration) {
   // Bail if upload is disabled for this file, or globally
   if (!shouldUpload(uploadFile, uploadGeneral)) return;
 
+  // Bail if there are no transactions for this file
+  if (!parsedFile.transactions.length) return;
+
   // Add YNAB-specific props to each transaction
   // This turns a BuddyTransaction into a YNAB.SaveTransaction
   const transactions: YNAB.SaveTransaction[] = parsedFile.transactions.map(


### PR DESCRIPTION
I have multiple bank files that I automatically export from my banking software, but they always cover only the last 10 days. As a result, some files are empty CSV files. While these files still get parsed, I encounter an error during the YNAB upload.

This change skips the transaction upload if the transactions array is empty.