### PR TITLE
Update exit message to include GitHub star request

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,18 +43,11 @@ To make ynab-buddy work seamlessly with your bank, open the config file and foll
 - Tech docs (for developers): [CONTRIBUTING.md](./CONTRIBUTING.md)
 - Please **DO NOT** contact YNAB Support. This is a community project, not an official YNAB service.
 
-## 😊 Coffee?
+## ☕ budget nerd + coffee = ynab-buddy 
 
 Did ynab-buddy save you some time? If so, consider showing your support by buying me a coffee! Your kind gesture helps me continue improving and maintaining this tool for the YNAB community.
 
-[☕ Buy me a coffee](https://ko-fi.com/nielsmaerten)
-
-Thank you for your support! 🙌
-
-## ⭐ GitHub Star
-
-If you like this tool, please leave a star on GitHub! Your support helps others discover this tool and motivates me to keep improving it.
-
+[☕ Buy me a coffee](https://ko-fi.com/nielsmaerten)  
 [⭐ Leave a star on GitHub](https://github.com/nielsmaerten/ynab-buddy)
 
 Thank you for your support! 🙌

--- a/README.md
+++ b/README.md
@@ -51,6 +51,14 @@ Did ynab-buddy save you some time? If so, consider showing your support by buyin
 
 Thank you for your support! 🙌
 
+## ⭐ GitHub Star
+
+If you like this tool, please leave a star on GitHub! Your support helps others discover this tool and motivates me to keep improving it.
+
+[⭐ Leave a star on GitHub](https://github.com/nielsmaerten/ynab-buddy)
+
+Thank you for your support! 🙌
+
 ## ⚠️ Disclaimer
 
 ynab-buddy is a **community-made tool** for YNAB.  

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -40,6 +40,7 @@ export const messages = {
   sponsor:
     "Did this tool just save you some time? Then maybe consider buying me a coffee:",
   sponsorLink: "https://go.niels.me/coffee",
+  githubStar: "If you like this tool, please leave a star on GitHub: https://github.com/nielsmaerten/ynab-buddy",
   exit: "Press any key to exit",
   newVersion: {
     notice: "A newer version of ynab-buddy is available.",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -40,7 +40,8 @@ export const messages = {
   sponsor:
     "Did this tool just save you some time? Then maybe consider buying me a coffee:",
   sponsorLink: "https://go.niels.me/coffee",
-  githubStar: "If you like this tool, please leave a star on GitHub: https://github.com/nielsmaerten/ynab-buddy",
+  githubStar: "Or, leave a star on GitHub:",
+  githubLink: "https://github.com/nielsmaerten/ynab-buddy",
   exit: "Press any key to exit",
   newVersion: {
     notice: "A newer version of ynab-buddy is available.",

--- a/src/lib/cli.ts
+++ b/src/lib/cli.ts
@@ -44,6 +44,8 @@ export function displayGoodbyeMessage() {
   console.log(messages.sponsor);
   console.log(chalk.bgBlueBright(messages.sponsorLink));
   console.log("");
+  console.log(messages.githubStar);
+  console.log("");
 }
 
 export async function exitApp() {

--- a/src/lib/cli.ts
+++ b/src/lib/cli.ts
@@ -45,6 +45,7 @@ export function displayGoodbyeMessage() {
   console.log(chalk.bgBlueBright(messages.sponsorLink));
   console.log("");
   console.log(messages.githubStar);
+  console.log(chalk.bgBlueBright(messages.githubLink));
   console.log("");
 }
 


### PR DESCRIPTION
Update the exit message to ask for a star on GitHub in addition to referring to the ko-fi page.

* Add a new `githubStar` message to the `messages` object in `src/constants.ts`.
* Update the `displayGoodbyeMessage` function in `src/lib/cli.ts` to include the new `githubStar` message.
* Add a section in `README.md` asking users to leave a star on GitHub in addition to the ko-fi page.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/nielsmaerten/ynab-buddy/pull/320?shareId=358c6cea-ffac-4a3b-99dd-a0f2f497b6bb).